### PR TITLE
Validates rejection notes only for rejected requests

### DIFF
--- a/Seravian/Controllers/AdminController.cs
+++ b/Seravian/Controllers/AdminController.cs
@@ -162,7 +162,16 @@ public class AdminController : ControllerBase
     public async Task<ActionResult> ReviewDoctorVerificationRequest(
         ReviewDoctorVerificationRequestRequestDto request
     )
-    {
+    { // rejection notes is only provided when rejected
+        if (request.IsApproved && !string.IsNullOrEmpty(request.RejectionNotes))
+        {
+            return BadRequest(
+                new
+                {
+                    Errors = new List<string> { "Rejection notes is only provided when rejected." },
+                }
+            );
+        }
         try
         {
             var verificationRequest = await _dbContext


### PR DESCRIPTION
Adds validation check to ensure rejection notes are only provided when a doctor verification request is rejected. Returns a BadRequest response with appropriate error message if rejection notes are provided for an approved request.