### PR TITLE
Removes emotion prefix from LLM input format

### DIFF
--- a/Seravian/Controllers/ChatController.cs
+++ b/Seravian/Controllers/ChatController.cs
@@ -528,8 +528,7 @@ public partial class ChatController : ControllerBase
 
                         System.IO.File.Delete(wavPath);
 
-                        var formatLLMInput =
-                            $"Emotion: {analysisResult.DominantEmotion}. Message: {analysisResult.Transcription}";
+                        var formatLLMInput = $"{analysisResult.Transcription}";
                         var userChatMessage = new ChatMessage
                         {
                             ChatId = chatId,


### PR DESCRIPTION
Simplifies the input format for the language model by only passing the transcription text without the emotion prefix. This change streamlines the message processing pipeline and removes potentially unnecessary emotional context from the LLM input.